### PR TITLE
Fix Bluesoft labs's link markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 - [ShopTalkShow](https://shoptalkshow.com/)
 - [Segurança Legal](https://www.segurancalegal.com)
 - [Área de transferência](https://areadetransferencia.com.br/)
-- [BlueSoft Labs] (http://labs.bluesoft.com.br/category/podcast/)
+- [BlueSoft Labs](http://labs.bluesoft.com.br/category/podcast/)
 - [Syntax.fm](https://syntax.fm/)
 - [React Podcast](https://reactpodcast.simplecast.fm/)
 - [Dev na Estrada](https://devnaestrada.com.br/)


### PR DESCRIPTION
Removi o espaço entre [Bluesoft Labs] e (http://labs.bluesoft.com.br/category/podcast/) que impedia a melhor renderização do link de acordo com a sintaxe do markdown